### PR TITLE
Allow custom docker daemon options

### DIFF
--- a/wrapper.sh
+++ b/wrapper.sh
@@ -2,7 +2,7 @@
 set -e
 
 echo "==> Launching the Docker daemon..."
-dind docker daemon --host=unix:///var/run/docker.sock --storage-driver=overlay &
+dind docker daemon --host=unix:///var/run/docker.sock --storage-driver=overlay $DOCKER_DAEMON_OPTIONS &
 
 while(! docker info > /dev/null 2>&1); do
     echo "==> Waiting for the Docker daemon to come online..."


### PR DESCRIPTION
This is specifically for `--insecure-registry=<>`, but can be used for other engine options.

In the Jenkins Manage System panel under Mesos>Advanced>Advanced, you can add the parameter:
- Key: `env`
- Value: `DOCKER_DAEMON_OPTIONS=--insecure-registry=my-registry.domain.tld`

This works with a version of the image I pushed at `yanatan16/jenkins-dind:0.2.2-2`
