### PR TITLE
[DO NOT MERGE] Upgrade pip and update glibc package.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,11 @@ MAINTAINER Mesosphere Support <support+jenkins-dind@mesosphere.com>
 # http://bugs.python.org/issue19846
 # > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
 ENV ALPINE_EDGE_COMMUNITY_REPO=http://dl-cdn.alpinelinux.org/alpine/edge/community \
-    ALPINE_GLIBC_BASE_URL=https://github.com/andyshinn/alpine-pkg-glibc/releases/download/unreleased \
-    ALPINE_GLIBC_PACKAGE=glibc-2.23-r1.apk \
-    ALPINE_GLIBC_BIN_PACKAGE=glibc-bin-2.23-r1.apk \
-    ALPINE_GLIBC_I18N_PACKAGE=glibc-i18n-2.23-r1.apk \
-    ANDY_SHINN_RSA_PUB_URL=https://raw.githubusercontent.com/andyshinn/alpine-pkg-glibc/master/andyshinn.rsa.pub \
+    ALPINE_GLIBC_BASE_URL=https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.23-r2/ \
+    ALPINE_GLIBC_PACKAGE=glibc-2.23-r2.apk \
+    ALPINE_GLIBC_BIN_PACKAGE=glibc-bin-2.23-r2.apk \
+    ALPINE_GLIBC_I18N_PACKAGE=glibc-i18n-2.23-r2.apk \
+    SGERRAND_RSA_PUB_URL=https://raw.githubusercontent.com/sgerrand/alpine-pkg-glibc/master/sgerrand.rsa.pub \
     JAVA_HOME=/usr/lib/jvm/default-jvm \
     LANG=en_US.UTF-8 \
     LANGUAGE=en_US.UTF-8 \
@@ -44,7 +44,7 @@ RUN apk --update add \
     virtualenv
     && cd /tmp \
     && apk add --update --repository ${ALPINE_EDGE_COMMUNITY_REPO} tini \
-    && wget -q -O /etc/apk/keys/andyshinn.rsa.pub "${ANDY_SHINN_RSA_PUB_URL}" \
+    && wget -q -O /etc/apk/keys/sgerrand.rsa.pub "${SGERRAND_RSA_PUB_URL}" \
     && wget -q "${ALPINE_GLIBC_BASE_URL}/${ALPINE_GLIBC_PACKAGE}" \
                "${ALPINE_GLIBC_BASE_URL}/${ALPINE_GLIBC_BIN_PACKAGE}" \
                "${ALPINE_GLIBC_BASE_URL}/${ALPINE_GLIBC_I18N_PACKAGE}" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ RUN apk --update add \
     && pip install --upgrade \
     pip \
     setuptools \
-    virtualenv
+    virtualenv \
     && cd /tmp \
     && apk add --update --repository ${ALPINE_EDGE_COMMUNITY_REPO} tini \
     && wget -q -O /etc/apk/keys/sgerrand.rsa.pub "${SGERRAND_RSA_PUB_URL}" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,10 @@ RUN apk --update add \
     python3 \
     tar \
     unzip \
+    && pip install --upgrade \
+    pip \
+    setuptools \
+    virtualenv
     && cd /tmp \
     && apk add --update --repository ${ALPINE_EDGE_COMMUNITY_REPO} tini \
     && wget -q -O /etc/apk/keys/andyshinn.rsa.pub "${ANDY_SHINN_RSA_PUB_URL}" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ RUN apk --update add \
     && wget -q "${ALPINE_GLIBC_BASE_URL}/${ALPINE_GLIBC_PACKAGE}" \
                "${ALPINE_GLIBC_BASE_URL}/${ALPINE_GLIBC_BIN_PACKAGE}" \
                "${ALPINE_GLIBC_BASE_URL}/${ALPINE_GLIBC_I18N_PACKAGE}" \
-    && apk add ${ALPINE_GLIBC_PACKAGE} ${ALPINE_GLIBC_BIN_PACKAGE} ${ALPINE_GLIBC_I18N_PACKAGE} \
+    && apk add --allow-untrusted ${ALPINE_GLIBC_PACKAGE} ${ALPINE_GLIBC_BIN_PACKAGE} ${ALPINE_GLIBC_I18N_PACKAGE} \
     && cd \
     && rm -rf /tmp/* /var/cache/apk/* \
     && /usr/glibc-compat/bin/localedef -i en_US -f UTF-8 en_US.UTF-8 \


### PR DESCRIPTION
Using Overlay FS and trying to upgrade pip in subsequent child images of this will result in errors and images being unable to build.

The glibc package also appears to have moved location since but the packages have yet to be signed correctly. This PR includes a commit to allow untrusted for testing purposes and _SHOULD NOT BE MERGED_ until this has been removed / fixed.

Related issues:
- https://github.com/docker/docker/issues/12327
- https://github.com/pypa/pip/issues/3507
