### PR TITLE
Bump to 1.11.2-dind which uses Alpine 3.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker:1.11-dind
+FROM docker:1.11.2-dind
 
 MAINTAINER Mesosphere Support <support+jenkins-dind@mesosphere.com>
 


### PR DESCRIPTION
Alpine 3.4 has a list of fixes that are valuable: https://alpinelinux.org/posts/Alpine-3.4.0-released.html
