### PR TITLE
Add JDK to ubuntu docker container 

### DIFF
--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -9,7 +9,6 @@ RUN apt-get update -y       \
        build-essential      \
        bzip2                \
        ca-certificates      \
-       ca-certificates-java \
        curl                 \
        git                  \
        iptables             \

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -16,7 +16,7 @@ RUN apt-get update -y       \
        jq                   \
        lvm2                 \
        lxc                  \
-       openjdk-8-jre-headless  \
+       openjdk-8-jdk-headless  \
        unzip                \
        zip
 


### PR DESCRIPTION
Current ubuntu container has only JRK installed which makes it useless for java projects.

`openjdk-8-jre-headless` has been replaced with `openjdk-8-jdk-headless` and `ca-certificates-java` has been removed as it has dependency to `openjdk-9-jre-headless` which messes up build environment, appropriate version should be automatically installed as `openjdk-8-jdk-headless` dependency.
