### PR TITLE
Dockerfile: upgraded to “LTS” Docker engine ver

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,4 +1,4 @@
-FROM docker:1.13.1-dind
+FROM docker:17.06.1-dind
 
 MAINTAINER Mesosphere Support <support+jenkins-dind@mesosphere.com>
 
@@ -32,6 +32,7 @@ RUN apk --update add \
     make \
     openjdk8 \
     openssh-client \
+    openssl \
     perl \
     py-pip \
     python \

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -19,7 +19,9 @@ RUN apt-get update -y       \
        unzip                \
        zip
 
-ENV DIND_COMMIT 092cba3727bb9b4a2f0e922cd6c0f93ea270e363
+# links to commit hashes are listed inside posted Dockerfiles https://hub.docker.com/r/library/docker/
+# NOTE: must match engine version that is directly pulled from Alpine's Dockerfile
+ENV DIND_COMMIT 3b5fac462d21ca164b3778647420016315289034
 # docker
 RUN curl -sSL https://get.docker.com | sh
 # fetch DIND script


### PR DESCRIPTION
Allows users to take advantage of multi-stage builds (available since 17.05), but in Docker's "LTS" engine (6-month releases)