### PR TITLE
WIP: upgrade to latest 17.x docker to get 3.7 alpine

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,4 +1,4 @@
-FROM docker:17.06.1-dind
+FROM docker:17.12.0-dind
 
 MAINTAINER Mesosphere Support <support+jenkins-dind@mesosphere.com>
 

--- a/Dockerfile.alpine-rpm
+++ b/Dockerfile.alpine-rpm
@@ -1,4 +1,4 @@
-FROM docker:17.06.1-dind
+FROM docker:17.12.0-dind
 
 MAINTAINER Mesosphere Support <support+jenkins-dind@mesosphere.com>
 

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -21,7 +21,7 @@ RUN apt-get update -y       \
 
 # links to commit hashes are listed inside posted Dockerfiles https://hub.docker.com/r/library/docker/
 # NOTE: must match engine version that is directly pulled from Alpine's Dockerfile
-ENV DIND_COMMIT 3b5fac462d21ca164b3778647420016315289034
+ENV DIND_COMMIT de9fda490429cf83734ef78b58f0ae9cfed1b087
 # docker
 RUN curl -sSL https://get.docker.com | sh
 # fetch DIND script

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -21,11 +21,15 @@ RUN apt-get update -y       \
 
 # links to commit hashes are listed inside posted Dockerfiles https://hub.docker.com/r/library/docker/
 # NOTE: must match engine version that is directly pulled from Alpine's Dockerfile
-ENV DIND_COMMIT de9fda490429cf83734ef78b58f0ae9cfed1b087
+# - go to https://hub.docker.com/r/library/docker/
+# - click on the matching alpine version tag (eg, 17.12.0-dind)
+# - pull the DIND_COMMIT has from the Dockerfile that opens, for 17.12.0-dind it will be:
+#   https://github.com/docker-library/docker/blob/de9fda490429cf83734ef78b58f0ae9cfed1b087/17.12/dind/Dockerfile
+ENV DIND_COMMIT 3b5fac462d21ca164b3778647420016315289034
 # docker
-RUN curl -sSL https://get.docker.com | sh
+RUN curl -fsSL https://get.docker.com | sh
 # fetch DIND script
-RUN curl -sSL https://raw.githubusercontent.com/docker/docker/${DIND_COMMIT}/hack/dind -o /usr/local/bin/dind \
+RUN curl -fsSL https://raw.githubusercontent.com/docker/docker/${DIND_COMMIT}/hack/dind -o /usr/local/bin/dind \
     && chmod a+x /usr/local/bin/dind
 
 COPY ./wrapper.sh /usr/local/bin/wrapper.sh


### PR DESCRIPTION
Stash/Unstash in Jenkins doesn't work with Alpine 3.6.2, but it's reported to work with Alpine 3.7. Short term fix is moving from Alpine to Ubuntu. We need to upgrade the Alpine version underpinning jenkins-dind:0.6.0-alpine and verify it fixes the stash/unstash problem without introducing any new problems.