### PR TITLE
Revert "Remove VOLUME declaration from ubuntu image"

### DIFF
--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -39,5 +39,6 @@ RUN curl -sSL https://raw.githubusercontent.com/docker/docker/${DIND_COMMIT}/hac
 COPY ./wrapper.sh /usr/local/bin/wrapper.sh
 RUN chmod a+x /usr/local/bin/wrapper.sh
 
+VOLUME /var/lib/docker
 ENTRYPOINT []
 CMD []


### PR DESCRIPTION
Reverts mesosphere/dcos-jenkins-dind-agent#28

Without the `VOLUME` declaration, running the docker daemon in the container reports issues running overlay on overlay.